### PR TITLE
Speeding up purging of array in Ruby

### DIFF
--- a/ruby/stalin_sort.rb
+++ b/ruby/stalin_sort.rb
@@ -1,10 +1,11 @@
 def stalin_sort(arr)
-  [] if arr.empty?
+  return [] if arr.empty?
 
   max = arr[0]
-  arr.select.with_index do |x,i| 
-    max = x if i == 0 or x > max
-    x >= max
+  arr.select do |x|
+    next if max > x
+    max = x
+    x
   end
 end
 


### PR DESCRIPTION
This implementation is about 2x times faster at purging the array of the unsatisfactory members, using ruby 2.6.0


```bash
Warming up --------------------------------------
     stalin_sort_old    52.808k i/100ms
     stalin_sort_new    91.415k i/100ms
Calculating -------------------------------------
     stalin_sort_old    567.271k (± 4.9%) i/s -      2.852M in   5.039282s
     stalin_sort_new      1.158M (± 4.1%) i/s -      5.851M in   5.059152s

Comparison:
     stalin_sort_new:  1158493.5 i/s
     stalin_sort_old:   567271.3 i/s - 2.04x  slower
```


```ruby
require 'benchmark/ips'

def stalin_sort_old(arr)
  [] if arr.empty?

  max = arr[0]
  arr.select.with_index do |x,i| 
    max = x if i == 0 or x > max
    x >= max
  end
end

def stalin_sort_new(arr)
  return [] if arr.empty?

  max = arr[0]
  arr.select do |x| 
    next if max > x
    max = x 
    x
  end
end

ARRAY1 = [1, 2,2, 10, 3, 4, 5, 15, 6, 30, 20]
ARRAY2 = ['a', 'c', 'b', 'a','c','d']


require 'benchmark/ips'

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.report("stalin_sort_old") { stalin_sort_old(ARRAY1) }
  x.report("stalin_sort_new") { stalin_sort_new(ARRAY1) }
  x.compare!
end
```