### PR TITLE
Add main.swift for executing sample of StalinSort.swift & fix a small bug

### DIFF
--- a/swift/StalinSort.swift
+++ b/swift/StalinSort.swift
@@ -7,7 +7,7 @@ extension Sequence where Element: Comparable {
         where C: RangeReplaceableCollection, C: RandomAccessCollection,
         C.Element == Element {
         return reduce(into: initialResult, { (result, element) in
-            if result.last.map({ $0 < element }) ?? true {
+            if result.last.map({ $0 <= element }) ?? true {
                 result.append(element)
             }
         })

--- a/swift/main.swift
+++ b/swift/main.swift
@@ -1,0 +1,11 @@
+// To execute this code
+// > swiftc main.swift StalinSort.swift -o main
+// > ./main
+
+let arr = [1, 2, 10, 3, 4, 5, 15, 6, 30, 20]
+let res = arr.stalinSort()
+
+print("Before")
+print(arr)
+print("After")
+print(res)

--- a/swift/main.swift
+++ b/swift/main.swift
@@ -2,10 +2,14 @@
 // > swiftc main.swift StalinSort.swift -o main
 // > ./main
 
-let arr = [1, 2, 10, 3, 4, 5, 15, 6, 30, 20]
-let res = arr.stalinSort()
+let inputs = [
+    [1, 2, 10, 3, 4, 5, 15, 6, 30, 20],
+    [1, 2, 10, 3, 4, 5, 15, 6, 30, 30],
+]
 
-print("Before")
-print(arr)
-print("After")
-print(res)
+inputs.forEach { arr in
+    print("Before")
+    print(arr)
+    print("After")
+    print(arr.stalinSort())
+}


### PR DESCRIPTION
- Add a sample script for executing swift version of stalin-sort .
- Fix a small bug. It happens when the array has consecutive same value. 
For example,
```
// input: [1, 2, 10, 3, 4, 5, 15, 6, 30, 30]
// output: [1, 2, 10, 15, 30] <- We expect this value [1, 2, 10, 15, 30, 30]
```