### PR TITLE
Add Stalin Sort in Shen

### DIFF
--- a/shen/stalin-sort.shen
+++ b/shen/stalin-sort.shen
@@ -1,0 +1,27 @@
+(datatype number-list
+
+  ___________________
+  [] : number-list;
+  
+  X: number; Y : number-list;
+  ==========================
+  [X | Y] : number-list;)
+
+
+(define stalin-sort
+  {number-list --> number-list}
+  
+  []            -> []
+  [X Y | Rest]  -> (stalin-sort [X | Rest]) where (> X Y)
+  [X | Rest]    -> [X | (stalin-sort Rest)])
+
+
+\* Tests *\
+(map stalin-sort
+     [[3 1 2 5 5 4 7 6 9 8]
+      [1 2 4 5 6 8 0 9 5 7]
+      [9 8 7 6 5 4 3 2 1 0]
+      [1 3 2 5 4 7 0 9 8 6]])
+
+\* This should fail out of type incorrectness *\
+\* (stalin-sort [1 2 + 3 4 5]) *\


### PR DESCRIPTION
Test results:

```
(2-) (map stalin-sort
          [[3 1 2 5 5 4 7 6 9 8]
           [1 2 4 5 6 8 0 9 5 7]
           [9 8 7 6 5 4 3 2 1 0]
           [1 3 2 5 4 7 0 9 8 6]])

[[3 5 5 7 9] [1 2 4 5 6 8 9] [9] [1 3 5 7 9]]
```

More about the language on http://shenlanguage.org