### PR TITLE
Fixed go statlin sort: Removed hardcoded 1 at first index

### DIFF
--- a/go/stalin-sort.go
+++ b/go/stalin-sort.go
@@ -1,8 +1,6 @@
-package main
+package stalinSort
 
-import "fmt"
-
-func StalinSort(arr []int) []int {
+func SortInts(arr []int) []int {
 	sorted := make([]int, 0)
 
 	for i := 0; i < len(arr); i++ {
@@ -14,10 +12,4 @@ func StalinSort(arr []int) []int {
 	}
 
 	return sorted
-}
-
-func main() {
-	arr := []int{1, 2, 10, 3, 2, 4, 15, 6, 30, 20}
-	resp := StalinSort(arr)
-	fmt.Println(resp)
 }

--- a/go/stalin-sort.go
+++ b/go/stalin-sort.go
@@ -3,12 +3,16 @@ package main
 import "fmt"
 
 func StalinSort(arr []int) []int {
-	sorted := []int{1}
-	for i := 1; i < len(arr); i++ {
-		if arr[i] > sorted[len(sorted)-1] {
+	sorted := make([]int, 0)
+
+	for i := 0; i < len(arr); i++ {
+		if i == 0 {
+			sorted = append(sorted, arr[i])
+		} else if arr[i] > sorted[len(sorted)-1] {
 			sorted = append(sorted, arr[i])
 		}
 	}
+
 	return sorted
 }
 

--- a/go/stalin-sort_test.go
+++ b/go/stalin-sort_test.go
@@ -1,0 +1,45 @@
+package stalinSort
+
+import "testing"
+
+type StalinSortTestCase struct {
+    Input []int
+    Expected []int
+}
+
+func GetTestCases() []StalinSortTestCase {
+    return []StalinSortTestCase {
+        StalinSortTestCase{
+            Input: []int{ 1, 2, 10, 3, 2, 4, 15, 6, 30, 20 },
+            Expected: []int{ 1, 2, 10, 15, 30 },
+        },
+        StalinSortTestCase{
+            Input: []int{ 78, 33, 100, 61, 65, 72, 11, 66, 89, 3 },
+            Expected: []int{ 78, 100 },
+        },
+        StalinSortTestCase{
+            Input: []int{ 2, 2, 3, 1, 10 },
+            Expected: []int{ 2, 3, 10 },
+        },
+    }
+}
+
+func TestSort(t *testing.T) {
+    testcases := GetTestCases()
+
+    for index, testcase := range testcases {
+        result := SortInts(testcase.Input)
+
+        if len(result) != len(testcase.Expected) {
+            t.Fatalf("Length of result (%d) does not match length of expected result (%d) for test case #%d",
+                len(result), len(testcase.Expected), index)
+        } else {
+            for i := 0; i < len(result); i++ {
+                if result[i] != testcase.Expected[i] {
+                    t.Fatalf("Expected %d at index %d but got %d instead for test case #%d",
+                        testcase.Expected[i], i, result[i], index)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The sorted slice has a hardcoded 1 at the first index. The provided example returns the correct result:

```
Input: 1, 2, 10, 3, 2, 4, 15, 6, 30, 20
Expected: 1, 2, 10, 15, 30
Result: 1, 2, 10, 15, 30
```

Given a different input without a leading 1 returns the wrong result:

```
Input: 2, 10, 3, 2, 4, 15, 6, 30, 20
Expected: 2, 10, 15, 30
Result: 1, 10, 15, 30
```