### PR TITLE
Updated / improved C# code

### DIFF
--- a/c#/stalin-sort/Program.cs
+++ b/c#/stalin-sort/Program.cs
@@ -16,11 +16,11 @@ public class Program
 	{
 		if (items.Any()) {
 			var comparer = Comparer<T>.Default;
-  			T last = items.First();
-			foreach (var i in items)
-				if (comparer.Compare(i, last) >= 0) {
-					last = i;
-					yield return i;
+  			T previousValue = items.First();
+			foreach (var currentValue in items)
+				if (comparer.Compare(currentValue, previousValue) >= 0) {
+					previousValue = currentValue;
+					yield return currentValue;
 				}
 		}
 	}

--- a/c#/stalin-sort/Program.cs
+++ b/c#/stalin-sort/Program.cs
@@ -17,11 +17,12 @@ public class Program
 		if (items.Any()) {
 			var comparer = Comparer<T>.Default;
   			T previousValue = items.First();
-			foreach (var currentValue in items)
+			foreach (var currentValue in items) {
 				if (comparer.Compare(currentValue, previousValue) >= 0) {
 					previousValue = currentValue;
 					yield return currentValue;
 				}
+			}
 		}
 	}
 }

--- a/c#/stalin-sort/Program.cs
+++ b/c#/stalin-sort/Program.cs
@@ -1,33 +1,27 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-
-namespace stalin_sort
+					
+public class Program
 {
-    class Program
-    {
-        static private int[] stalinSort(int[] array)
-        {
-        	if (array.Length == 0) return array;//empty array is already sorted. yay!
-        	
-            var sortedArray = new List<int>() { array[0] }; //resulting array always contains the first element
-            
-            for (int i = 1; i < array.Length; i++)
-            {
-                if (array[i] >= sortedArray.Last()) 
-                	sortedArray.Add(array[i]);
-            }
-            
-            return sortedArray.ToArray();
-        } 
-        static void Main(string[] args)
-        {
-            int[] array = new int[]{1, 2, 4, 3, 6, 8, 0, 9, 5, 7};
-            
-            int[] sortedArray = stalinSort(array);
-            
-            Console.WriteLine("{0}", string.Join(", ", sortedArray));
-        }
-    }
+	public static void Main()
+	{
+		var array = new int[]{ 1, 2, 4, 3, 6, 8, 0, 8, 9, 5, 7};
+		
+		Console.WriteLine("{0}", string.Join(", ", StalinSort(array)));
+	}
+	
+	public static IEnumerable<T> StalinSort<T>(IEnumerable<T> items) 
+		where T: IComparable<T> 
+	{
+		if (items.Any()) {
+			var comparer = Comparer<T>.Default;
+  			T last = items.First();
+			foreach (var i in items)
+				if (comparer.Compare(i, last) >= 0) {
+					last = i;
+					yield return i;
+				}
+		}
+	}
 }


### PR DESCRIPTION
Now works with all sorts of items as long as they implement `IComparable<T>`. Naming has also changed from `stalinSort` to `StalinSort` ([methods should be PascalCased](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions#capitalization-rules-for-identifiers)). The method now accepts an `IEnumerable<T>` which allows for more types of inputs than just arrays and, consequently, also returns an `IEnumerable<T>`. Finally, no unnecessary allocations are made since items are simply yielded during the (single) iteration.