### PR TITLE
O(n) C implementation

### DIFF
--- a/C/stalinSort.c
+++ b/C/stalinSort.c
@@ -1,21 +1,30 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int *stalinSort(int *arr, int size, int *newSize) {
-    int i;
-    int *sortedArr;
+#define max(a, b) ((a)>(b)?(a):(b))
 
-    sortedArr = (int*) malloc(sizeof(int));
-    sortedArr[0] = arr[0];
+int* stalin_sort(int* arr, int size, int* newsz) {
+	int newSize = 0, maxv = arr[0];
 
-    for (i = 1; i < size; ++i) {
-        if (arr[i] >= sortedArr[(*newSize)-1]) {
-            ++(*(newSize));
-            sortedArr = (int*) realloc(sortedArr, *newSize * sizeof(int));
-            sortedArr[*newSize-1] = arr[i];
-        }
-    }
-    return sortedArr;
+	// compute new size
+	for (int i=0; i < size; ++i) {
+		newSize += (arr[i] >= maxv);
+		maxv = max(arr[i], maxv);
+	}
+
+	// fill new array
+	int _ar[newSize], k=1;
+	_ar[0] = arr[0];
+	for (int i=1; i < size; ++i)
+		if (arr[i] >= _ar[k-1]) _ar[k++] = arr[i];
+
+	// move sorted items to end of original array
+	int j = size - newSize;
+	for (int i=0; i < newSize; ++i, ++j)
+		arr[j] = _ar[i];
+
+	*newsz = newSize;
+	return arr + (size - newSize);
 }
 
 int main(int argc, char const *argv[]) {
@@ -23,13 +32,12 @@ int main(int argc, char const *argv[]) {
     int *sortedArr;
     int array[10] = {1, 2, 4, 3, 6, 8, 0, 9, 5, 7};
     
-    sortedArr = stalinSort(array, 10, &newSize);
+    sortedArr = stalin_sort(array, 10, &newSize);
 
     for (i = 0; i < newSize; ++i)
         (void) printf("%i ", sortedArr[i]);
 
     (void) printf("\n");
 
-    free(sortedArr);
     return 0;
 }


### PR DESCRIPTION
C implementation of the stalin sort without malloc() and realloc(), sorts inplace.

It may blow up the stack size if the array size is `really large and mostly sorted`, then in that case it'd make sense to malloc() and free() inside the stalin_sort() function, not outside.