### PR TITLE
Make Stalin go efficient.

### DIFF
--- a/go/stalin/stalin.go
+++ b/go/stalin/stalin.go
@@ -1,0 +1,29 @@
+// Package stalin is efficient and dangerous.
+// This is free software released into the public domain.
+package stalin
+
+// Sort orders list and returns the new length.
+// Any remaining integers are set to zero.
+func Sort(list []int) int {
+	if len(list) < 2 {
+		return len(list)
+	}
+
+	n := 1
+	highest := list[0]
+	for i := 1; i < len(list); i++ {
+		next := list[i]
+		if next > highest {
+			highest = next
+			list[n] = next
+			n++
+		}
+	}
+
+	// no trace
+	for i := n; i < len(list); i++ {
+		list[i] = 0
+	}
+
+	return n
+}

--- a/go/stalin/stalin.go
+++ b/go/stalin/stalin.go
@@ -13,7 +13,7 @@ func Sort(list []int) int {
 	highest := list[0]
 	for i := 1; i < len(list); i++ {
 		next := list[i]
-		if next > highest {
+		if next >= highest {
 			highest = next
 			list[n] = next
 			n++

--- a/go/stalin/stalin_test.go
+++ b/go/stalin/stalin_test.go
@@ -1,0 +1,59 @@
+package stalin
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSort(t *testing.T) {
+	golden := []struct {
+		Got, Want []int
+	}{
+		{
+			[]int{1, 2, 10, 3, 2, 4, 15, 6, 30, 20},
+			[]int{1, 2, 10, 15, 30},
+		},
+	}
+
+	for _, gold := range golden {
+		list := make([]int, len(gold.Got))
+		copy(list, gold.Got)
+		n := Sort(list)
+
+		got := list[:n]
+		if !reflect.DeepEqual(got, gold.Want) {
+			t.Errorf("%v: got %v, want %v", gold.Got, got, gold.Want)
+		}
+
+		remaining := list[n:]
+		if !reflect.DeepEqual(remaining, make([]int, len(remaining))) {
+			t.Errorf("%v: remaining not zero: %v", gold.Got, remaining)
+		}
+	}
+}
+
+func BenchmarkSort(b *testing.B) {
+	sample := []int{1, 2, 10, 3, 2, 4, 15, 6, 30, 20}
+	list := make([]int, len(sample))
+
+	b.Run("stalin", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			copy(list, sample)
+			Sort(list)
+		}
+	})
+
+	b.Run("quick", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			copy(list, sample)
+			sort.Ints(list)
+		}
+	})
+
+	b.Run("overhead", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			copy(list, sample)
+		}
+	})
+}


### PR DESCRIPTION
Sorts in 15ns. ☭

```
goarch: amd64
BenchmarkSort/stalin-4         	56458594	        21.5 ns/op
BenchmarkSort/quick-4          	 7310055	       161 ns/op
BenchmarkSort/overhead-4       	183858218	         6.52 ns/op
PASS
```