### PR TITLE
FORTH implementation of Stalin sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+*.swp

--- a/forth/stalin-sort.fth
+++ b/forth/stalin-sort.fth
@@ -1,0 +1,30 @@
+: LIST ( size -- )
+    CREATE DUP , CELLS ALLOT
+;
+
+: LIST@ ( index list -- value )
+    SWAP 1 + CELLS + @
+;
+
+: LIST! ( value index list -- )
+    SWAP 1 + CELLS + !
+;
+
+: STALINSORT ( list -- sorted-list )
+    0 OVER LIST@ SWAP 1 SWAP DUP @ 1
+    DO
+        I OVER LIST@ ROT ROT >R >R 2DUP
+        > IF
+            DROP
+            0
+        ELSE
+            1
+        THEN
+        R> + R> 
+    LOOP
+    2DUP ! SWAP 0 SWAP 1 -
+    DO
+        I OVER >R SWAP LIST! R>
+    -1
+    +LOOP
+;


### PR DESCRIPTION
STALINSORT expects the input in a buffer whose first cell contains the (used) length of the rest of the buffer, and performs the sort in-place. This is because I stuck to just the core word set when implementing the sort, and as such didn't have access to a good way to dynamically allocate a buffer for output.

Tested with gforth (it broke my homebrewed FORTH interpreter, which means more work for me)