### PR TITLE
Create StalinSortFolder.fs

### DIFF
--- a/f#/StalinSortFolder.fs
+++ b/f#/StalinSortFolder.fs
@@ -1,0 +1,9 @@
+// stalinSort : x:'a list -> 'a list when 'a : comparison
+let stalinSort x =
+    let folder acc v =
+        match List.last acc with
+        | max when max <= v -> acc @ [v]
+        | _ -> acc
+    match x with
+    | [] -> []
+    | head :: tail -> List.fold folder [head] tail


### PR DESCRIPTION
A new version of Stalin Sort in F# that doesn't require recursion. Works on lists of any type that supports comparison.