### PR TITLE
add cobol implementation

### DIFF
--- a/cobol/StalinSort.cbl
+++ b/cobol/StalinSort.cbl
@@ -1,0 +1,58 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. SORTVECT.
+       AUTHOR. COMRADE STALIN
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  I                 PIC 9(4) COMP.
+       01  S                 PIC 9(4) COMP.
+       01  VECTOR-LENGTH     PIC 9(4) COMP VALUE 10.
+       01  VECTOR.
+           02 VEC            PIC 9(4) OCCURS 10 TIMES.
+       01  SORTED-VECTOR.
+           02 SVEC           PIC 9(4) OCCURS 10 TIMES.
+       01  MAX              PIC 9(4) VALUE ZERO.
+
+       PROCEDURE DIVISION.
+       MAIN SECTION.
+      *    INITIALIZE VECTOR (YEP, HAVEN'T FIND A LITERAL INIT WAY YET)
+      *    VALUES: 6, 8, 5, 9, 11, 12, 4, 2, 7, 9
+           MOVE 6 TO VEC(1)
+           MOVE 8 TO VEC(2)
+           MOVE 5 TO VEC(3)
+           MOVE 9 TO VEC(4)
+           MOVE 11 TO VEC(5)
+           MOVE 12 TO VEC(6)
+           MOVE 4 TO VEC(7)
+           MOVE 2 TO VEC(8)
+           MOVE 7 TO VEC(9).
+           MOVE 9 TO VEC(10).
+
+           DISPLAY "in array"
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > VECTOR-LENGTH
+              DISPLAY VEC(I) " " WITH NO ADVANCING
+           END-PERFORM.
+
+           DISPLAY " ".
+           DISPLAY "out array".
+           PERFORM STALIN-SORT.
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > VECTOR-LENGTH
+              DISPLAY SVEC(I) " " WITH NO ADVANCING
+           END-PERFORM.
+           DISPLAY " ".
+           
+           STOP RUN.
+
+
+       STALIN-SORT SECTION.
+           MOVE 1 TO S.
+           MOVE VEC(1) TO MAX
+           PERFORM VARYING I FROM 2 BY 1 UNTIL I > VECTOR-LENGTH 
+              IF VEC(I) >= MAX
+                  MOVE MAX TO SVEC(S)
+                  ADD 1 TO S
+                  MOVE VEC(I) TO MAX
+              END-IF 
+           END-PERFORM.
+           MOVE MAX TO SVEC(S).


### PR DESCRIPTION
## How to run
You are to install `Open Cobol`. If you are using `ubuntu` - no difficulties (I personally gave up installing cobol for windows attempts and used wsl). For other unix-like systems package manager command should differ. Anyway, if on ubuntu, run
```bash
sudo apt-get install open-cobol
```
then `cd` to `cobol/` folder and run
```bash
cobc -x StalinSort.cbl
```
This should produce an executable, named `StalinSort`, which could be run as `./StalinSort`

DO NOT untabify the file! First blank 6 symbols by standard are used for line number field by compiler and 7-th is for asterisk, that marks commented lines.