### PR TITLE
Implement stalinSort in Clean

### DIFF
--- a/clean/StalinSort.dcl
+++ b/clean/StalinSort.dcl
@@ -1,0 +1,5 @@
+definition module StalinSort
+
+from StdOverloaded import class <
+
+stalinSort :: [a] -> [a] | < a

--- a/clean/StalinSort.icl
+++ b/clean/StalinSort.icl
@@ -1,0 +1,10 @@
+implementation module StalinSort
+
+import StdEnv
+
+stalinSort :: [a] -> [a] | < a
+stalinSort [] = []
+stalinSort [x] = [x]
+stalinSort [x, y : zs]
+	| x <= y = [x : stalinSort [y : zs]]
+	| otherwise = stalinSort [x : zs]


### PR DESCRIPTION
An implementation in [Clean](https://clean.cs.ru.nl/Clean). Clean is a rather old (~1987) programming language with the same roots as Haskell.