### PR TITLE
Add x86 assembly and compile-time TypeScript implementations

### DIFF
--- a/asm/x86/README.md
+++ b/asm/x86/README.md
@@ -1,0 +1,9 @@
+x86-64 implementation of Stalin sort in `stalin.asm`
+
+Example in `test.asm`. Compile and run with:
+```
+nasm -felf64 test.asm
+ld -melf_x86_64 -o test test.o
+chmod +x test
+./test
+```

--- a/asm/x86/stalin-sort.asm
+++ b/asm/x86/stalin-sort.asm
@@ -1,0 +1,36 @@
+[bits 64]
+
+; == STALIN SORT ==
+; Sorts the array by eliminating each element that is not in order
+;
+; ds:rsi = input array ptr (signed qwords) [clobbered, data intact]
+; ds:rdi = output array ptr (signed qwords) [clobbered, data output]
+; r8 = size of input array [clobbered]
+; r9 = size of output array [output]
+stalin_sort:
+    xor r9, r9
+    mov rbx, [rdi]
+
+_do_stalin:
+    ; return if reached end
+    cmp r8, 0
+    je _do_stalin_end
+
+    ; read next element
+    mov rax, [rsi]
+    add rsi, 8
+    dec r8
+
+    ; copy element if >= last
+    cmp rax, rbx
+    jl _do_stalin
+    mov [rdi], rax
+    add rdi, 8
+    inc r9
+
+    ; remember last element
+    mov rbx, rax
+    jmp _do_stalin
+
+_do_stalin_end:
+    ret

--- a/asm/x86/test.asm
+++ b/asm/x86/test.asm
@@ -1,0 +1,44 @@
+[bits 64]
+
+jmp _start
+
+%define input_len 11
+input: dq 1, 2, 4, 3, 6, 5, 4, 3, 9, 6, 8
+; expected output: 1, 2, 4, 6, 9
+
+_start:
+    ; call stalin
+    mov rsi, input
+    sub rsp, input_len * 8
+    mov rdi, rsp
+    push rdi
+    mov r8, input_len
+    call stalin_sort
+    pop rbx
+
+    ; print elements
+    mov rax, 1 ; sys_write
+    mov rdx, 1 ; count
+    mov rdi, 1 ; output
+    push byte 0 ; single-byte buffer
+    mov rsi, rsp
+.print_loop:
+    cmp r9, 0
+    je .print_end
+    mov cl, byte [rbx]
+    mov byte [rsp], cl ; byte to digit (single digits only :<)
+    add byte [rsp], '0'
+    add rbx, 8
+    dec r9
+    syscall
+    mov byte [rsp], ' '
+    syscall
+    jmp .print_loop
+
+.print_end:
+    ; exit
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+%include "stalin-sort.asm"

--- a/typescript/stalin-sort-compiletime.ts
+++ b/typescript/stalin-sort-compiletime.ts
@@ -1,0 +1,15 @@
+type StalinSort<Arr extends number[], Last extends number = Arr[0]> =
+    // stupid type guards
+    Arr extends [infer Elem, ...infer Rest] ? Elem extends number ? Rest extends number[]
+        ? GreaterOrEqual<Elem, Last> extends true
+            ? [Elem, ...StalinSort<Rest, Elem>]
+            : StalinSort<Rest, Last>
+    : never : never : Arr;
+
+type GreaterOrEqual<A extends number, B extends number> =
+    NumToArr<A> extends [...NumToArr<B>, ...infer Rem]
+    ? true : false;
+
+type NumToArr<N extends number, Acc extends any[] = []> = Acc["length"] extends N
+    ? Acc
+    : NumToArr<N, [...Acc, any]>;


### PR DESCRIPTION
x86-64 implementation of Stalin sort in `stalin.asm`

Example in `test.asm`. Compile and run with:
```
nasm -felf64 test.asm
ld -melf_x86_64 -o test test.o
chmod +x test
./test
```
