### PR TITLE
Kotlin: inplace sort; naming; minor improvement of the old sort

### DIFF
--- a/kotlin/StalinSort.kt
+++ b/kotlin/StalinSort.kt
@@ -20,18 +20,6 @@ fun <T : Comparable<T>> MutableIterable<T>.stalinSort() {
     }
 }
 
-fun <T: Comparable<T>> Iterable<T>.sortComradesOld(): List<T> {
-    var previous = firstOrNull() ?: return emptyList()
-    return mapIndexedNotNull { index, comrade ->
-        if (index == 0 || comrade >= previous) {
-            previous = comrade
-            comrade
-        } else {
-            null
-        }
-    }
-}
-
 fun <T : Comparable<T>> Iterable<T>.sortComrades(): List<T> {
     var previous = firstOrNull() ?: return emptyList()
     return mapNotNull { comrade ->

--- a/kotlin/StalinSort.kt
+++ b/kotlin/StalinSort.kt
@@ -1,22 +1,26 @@
-fun main(args: Array<String>) {
-    val intComrades = listOf(0, 2, 1, 4, 3, 6, 5).sortComrades()
-    
-    val charComrades = listOf('A', 'C', 'B', 'E', 'D').sortComrades()
+fun <T : Comparable<T>> Iterable<T>.stalinSorted(): List<T> =
+    if (none()) emptyList()
+    else {
+        var previous = first()
+        filter { next ->
+            if (next >= previous) true.also { previous = next }
+            else false
+        }
+    }
 
-    val redArmyRanks =  listOf(
-        RedArmyRank.SOLDIER, 
-        RedArmyRank.ASSISTANT_PLATOON_LEADER,
-        RedArmyRank.SQUAD_LEADER).sortComrades()
-    
-    val dickwads = listOf(
-        RedArmyDickwad("Stalin", RedArmyRank.SUPREME_COMMANDER),
-        RedArmyDickwad("Pablo", RedArmyRank.NOT_EVEN_RUSSIAN),
-        RedArmyDickwad("Putin", RedArmyRank.BEAR_RIDER)).sortComrades()
-    
-    println("$intComrades\n$charComrades\n$redArmyRanks\n$dickwads")
+fun <T : Comparable<T>> MutableIterable<T>.stalinSort() {
+    val it = iterator()
+    if (!it.hasNext()) return
+    var previous = it.next()
+    var curr: T
+    while (it.hasNext()) {
+        curr = it.next()
+        if (curr < previous) it.remove()
+        else previous = curr
+    }
 }
 
-fun <T: Comparable<T>> Iterable<T>.sortComrades(): List<T> {
+fun <T: Comparable<T>> Iterable<T>.sortComradesOld(): List<T> {
     var previous = firstOrNull() ?: return emptyList()
     return mapIndexedNotNull { index, comrade ->
         if (index == 0 || comrade >= previous) {
@@ -28,19 +32,14 @@ fun <T: Comparable<T>> Iterable<T>.sortComrades(): List<T> {
     }
 }
 
-enum class RedArmyRank {
-    NOT_EVEN_RUSSIAN,
-    SOLDIER,
-    SQUAD_LEADER,
-    ASSISTANT_PLATOON_LEADER,
-    COMPANY_SERGEANT,
-    BEAR_RIDER,
-    SUPREME_COMMANDER
-}
-
-data class RedArmyDickwad(
-    val name: String,
-    val rank: RedArmyRank
-) : Comparable<RedArmyDickwad> {
-    override operator fun compareTo(other: RedArmyDickwad) = rank.compareTo(other.rank)
+fun <T : Comparable<T>> Iterable<T>.sortComrades(): List<T> {
+    var previous = firstOrNull() ?: return emptyList()
+    return mapNotNull { comrade ->
+        if (comrade >= previous) {
+            previous = comrade
+            comrade
+        } else {
+            null
+        }
+    }
 }

--- a/kotlin/Test.kt
+++ b/kotlin/Test.kt
@@ -1,0 +1,112 @@
+import java.util.concurrent.Callable
+import kotlin.random.Random
+import kotlin.time.measureTime
+import kotlin.time.measureTimedValue
+
+fun main() {
+    emptyTest()
+    simpleTest()
+    comradesTest()
+    stressTest()
+    measureStalinSortTime { Random.nextInt() }
+    measureStalinSortTime { RedArmyRank.entries.random() }
+    val k = mutableListOf(1, 2, 3)
+    k.sorted()
+}
+
+fun emptyTest() {
+    val nothing: List<Int> = emptyList()
+    kgbCheck(nothing, nothing.sortComrades(), "sortComrades")
+    kgbCheck(nothing, nothing.stalinSorted(), "stalinSorted")
+    kgbCheck(nothing, nothing.toMutableList().also { it.stalinSort() }, "stalinSort")
+    println("simple test OK")
+}
+
+fun simpleTest() {
+    val intList = listOf(1, 2, 3, 4, 5, 2)
+    val stalinSorted = listOf(1, 2, 3, 4, 5)
+    kgbCheck(stalinSorted, intList.sortComrades(), "sortComrades")
+    kgbCheck(stalinSorted, intList.stalinSorted(), "stalinSorted")
+    kgbCheck(stalinSorted, intList.toMutableList().also { it.stalinSort() }, "stalinSort")
+    println("simple test OK")
+}
+
+fun comradesTest() {
+    val dickwadList = listOf(
+        RedArmyDickwad("Pablo", RedArmyRank.NOT_EVEN_RUSSIAN),
+        RedArmyDickwad("Legasov", RedArmyRank.SQUAD_LEADER),
+        RedArmyDickwad("You", RedArmyRank.SOLDIER),
+        RedArmyDickwad("Dyatlov", RedArmyRank.SQUAD_LEADER),
+        RedArmyDickwad("Trotsky", RedArmyRank.ASSISTANT_PLATOON_LEADER),
+        RedArmyDickwad("Shcherbina", RedArmyRank.SQUAD_LEADER),
+        RedArmyDickwad("Stalin", RedArmyRank.SUPREME_COMMANDER),
+        RedArmyDickwad("Gorki", RedArmyRank.BEAR_RIDER),
+        RedArmyDickwad("Voroshilov", RedArmyRank.COMPANY_SERGEANT)
+    )
+    val stalinSorted = dickwadList.slice(listOf(0, 1, 3, 4, 6))
+    kgbCheck(stalinSorted, dickwadList.sortComrades(), "sortComrades")
+    kgbCheck(stalinSorted, dickwadList.stalinSorted(), "stalinSorted")
+    kgbCheck(stalinSorted, dickwadList.toMutableList().also { it.stalinSort() }, "stalinSort")
+    println("comrades test OK")
+}
+
+fun stressTest() {
+    repeat(10) {
+        val stalinSort = MutableList(10000) { Random.nextDouble() }
+        val sortComrades = stalinSort.sortComrades()
+        val stalinSorted = stalinSort.stalinSorted()
+        stalinSort.stalinSort()
+        kgbCheck(stalinSort, sortComrades, "stalinSort vs sortComrades")
+        kgbCheck(sortComrades, stalinSorted, "sortComrades vs stalinSorted")
+    }
+    println("stress test OK")
+}
+
+fun <T : Comparable<T>> measureStalinSortTime(provider: Callable<T>) {
+    val scTimes: MutableList<Long> = mutableListOf()
+    val ssTimes: MutableList<Long> = mutableListOf()
+    val ssdTimes: MutableList<Long> = mutableListOf()
+    repeat(10) {
+        val randomList = MutableList(100000) { provider.call() }
+        val (sortComrades, sortComradesTime) = measureTimedValue { randomList.sortComrades() }
+        val (stalinSorted, stalinSortedTime) = measureTimedValue { randomList.stalinSorted() }
+        val stalinSort = randomList.toMutableList()
+        val stalinSortTime = measureTime { stalinSort.stalinSort() }
+        assert(sortComrades == stalinSorted)
+        assert(stalinSorted == stalinSort)
+        if (it > 4) {
+            scTimes.add(sortComradesTime.inWholeNanoseconds)
+            ssTimes.add(stalinSortedTime.inWholeNanoseconds)
+            ssdTimes.add(stalinSortTime.inWholeNanoseconds)
+        }
+    }
+    println("sortComrades time: ${scTimes.average()}")
+    println("stalinSorted time: ${ssTimes.average()}")
+    println("stalinSort time: ${ssdTimes.average()}")
+}
+
+
+enum class RedArmyRank {
+    NOT_EVEN_RUSSIAN,
+    SOLDIER,
+    SQUAD_LEADER,
+    ASSISTANT_PLATOON_LEADER,
+    COMPANY_SERGEANT,
+    BEAR_RIDER,
+    SUPREME_COMMANDER
+}
+
+data class RedArmyDickwad(
+    val name: String,
+    val rank: RedArmyRank
+) : Comparable<RedArmyDickwad> {
+    override operator fun compareTo(other: RedArmyDickwad) = rank.compareTo(other.rank)
+}
+
+fun <T> kgbCheck(expected: T, actual: T, whoToBlame: String) =
+    check(expected == actual) {
+        """KGB finds $whoToBlame unsatisfactory
+            Expected: $expected
+            Actual: $actual
+            """.trimIndent()
+    }


### PR DESCRIPTION
First of all, according to the contributing guideline the sort should be named `stalinSort`, but was `sortComrades`.   
Then, in Kotlin `sort` sorts inplace, while `sorted` returns a new list. So I've made 2 other implementations that follow this convention.   
A minor improvement of the exisinting implementation: index is not ractually required, since `previous` is guaranteed to be not null.  
Last but not least: some tests.