### PR TITLE
stalin-sort.js remade

### DIFF
--- a/javascript/stalin-sort.js
+++ b/javascript/stalin-sort.js
@@ -1,12 +1,17 @@
 function stalinSort(array) {
-  if (!Array.isArray(array)) throw new TypeError('Argument must be an Array!');
-
-  return array.reduce((prev, next) =>
-    !prev.length ||
-      next >= prev[prev.length - 1] ?
-        [...prev, next] :
-        prev
-  , []);
+  if (!Array.isArray(array)) {
+    throw new TypeError('stalinSort: Argument must be an Array')
+  }
+  let i = 1
+  let j = 1
+  for (; i < array.length; i++) {
+    if (array[i] >= array[j - 1]) {
+      array[j] = array[i]
+      j++
+    }
+  }
+  array.length = j
+  return array
 }
 
-module.exports = stalinSort
+module.exports = stalinSort;


### PR DESCRIPTION
- Alike Array.sort(), the function now modifies the array in place. It won't be StalinSort enough, if you'd be able to bring those values back.

- Sped it up. The previous version had reallocation issues, which not only were slower themself, but also led to speed losses on arrays with lots of values in the resulting array (e.g. when values are already sorted or nearly-sorted, or when there are lots of duplicates). Now it only truncates the array once. Speed gain is 2 to hundreds times, depending on the input array values, since the new algo executes in close to only length-dependent time.