### PR TITLE
Lean 4 stalin sort implementation

### DIFF
--- a/lean4/stalinsort.lean
+++ b/lean4/stalinsort.lean
@@ -1,0 +1,8 @@
+
+
+def stalinSort [LE α] [DecidableRel ((·<=·) : α → α → Prop)] : List α → List α
+| []          => []
+| [x]         => [x]
+| (x::y::zs)  =>
+  if x <= y then x :: stalinSort (y :: zs)
+  else stalinSort (x :: zs)


### PR DESCRIPTION
Lean 4 is a programming language and theorem prover

You can test the implementation at [Lean 4 Web](https://live.lean-lang.org/#code=def%20stalinSort%20%5BLE%20%CE%B1%5D%20%5BDecidableRel%20((%C2%B7%3C%3D%C2%B7)%20%3A%20%CE%B1%20%E2%86%92%20%CE%B1%20%E2%86%92%20Prop)%5D%20%3A%20List%20%CE%B1%20%E2%86%92%20List%20%CE%B1%0D%0A%7C%20%5B%5D%20%20%20%20%20%20%20%20%20%20%3D%3E%20%5B%5D%0D%0A%7C%20%5Bx%5D%20%20%20%20%20%20%20%20%20%3D%3E%20%5Bx%5D%0D%0A%7C%20(x%3A%3Ay%3A%3Azs)%20%20%3D%3E%0D%0A%20%20if%20x%20%3C%3D%20y%20then%20x%20%3A%3A%20stalinSort%20(y%20%3A%3A%20zs)%0D%0A%20%20else%20stalinSort%20(x%20%3A%3A%20zs)%0D%0A%0D%0A%23eval%20stalinSort%20%5B1%2C2%2C3%2C5%2C2%2C6%5D)

Using the `#eval` to pass in the desired list