### PR TITLE
Fixed bug in Red version and added Rebol version (as a module)

### DIFF
--- a/Rebol/stalin-sort-test.r3
+++ b/Rebol/stalin-sort-test.r3
@@ -1,0 +1,18 @@
+Rebol [
+	title:  "Stalin Sort usage example"
+	needs:   2.101.0 ;; or newer (https://github.com/Oldes/Rebol3/releases/)
+]
+
+import %stalin-sort.reb
+
+foreach input [
+	[1 2 5 3 2 1 5 7]
+	"chaotic"
+	#{deadbeef}
+	[#"s" #"t" #"a" #"l" #"i" #"n"]
+][
+	print ["Input: " mold input]
+	print ["Output:" mold stalin-sort input]
+	print ""
+]
+ask "Press enter to quit."

--- a/Rebol/stalin-sort.reb
+++ b/Rebol/stalin-sort.reb
@@ -1,0 +1,16 @@
+Rebol [
+	title:  "Stalin Sort"
+	name:    stalin-sort
+	type:    module
+	exports: [stalin-sort]
+	needs:   2.101.0 ;; or newer (https://github.com/Oldes/Rebol3/releases/)
+	note:    "Ported from the @gurzgri's Red version as a module"
+]
+
+stalin-sort: function ["Stalin-sorts a series (modified)." values [series!]][
+	parse values [any [
+		set foo: skip
+		remove any [set bar: skip if (lesser? bar foo)]
+	]]
+	values
+]

--- a/Red/stalin-sort.red
+++ b/Red/stalin-sort.red
@@ -7,7 +7,7 @@ Red [
 	]
 ]
 
-stalin-sort: function ["Stalin-sorts a series (modified)." values [series!]][
+stalin-sort: func ["Stalin-sorts a series (modified)." values [series!] /local foo bar][
 	parse values [any [
 		set foo skip
 		remove any [set bar skip if (lesser? bar foo)]


### PR DESCRIPTION
In Red and Rebol, the `function` keyword automatically collects _set-words_ and makes them local by default. However, since no _set-words_ were used in the Red version, they were not collected as locals.

It may be demonstrated in code like:
```red
>> a: "foo"
== "foo"
>> fun: function [][parse "abc" [copy a to end] probe a]
== func [][parse "abc" [copy a to end] probe a]
>> fun
"abc"
== "abc"
>> ? a ;; `a` was unintentionally modified!
A is a string! value: "abc"
```

In Red, it is currently not possible to use _set-words_ in the parse dialect. As a workaround, you need to define any local variables manually using the `/local` refinement in the function specification:

```red
>> a: "foo"
== "foo"
>> fun: function [/local a][parse "abc" [copy a to end] probe a]
== func [/local a][parse "abc" [copy a to end] probe a]
>> fun
"abc"
== "abc"
>> ? a ;; `a` retains its original content
A is a string! value: "foo"
```