### PR TITLE
Add IBM RPG implementation

### DIFF
--- a/IBM RPG IV/stalin-sort-example-fixed-form.rpgle
+++ b/IBM RPG IV/stalin-sort-example-fixed-form.rpgle
@@ -1,0 +1,52 @@
+     H DftActGrp(*No)
+
+     DARR              S             10I 0 DIM(6)
+     DSIZE             S              3U 0 INZ(6)
+     DI                S              3U 0
+     DMSG              S             52A   VARYING INZ('New Size : ')
+
+     DSTALIN_SORT      PR
+     D *N                            10I 0 DIM(6)
+     D *N                             3U 0
+
+     C                   Z-ADD     1             ARR(1)
+     C                   Z-ADD     2             ARR(2)
+     C                   Z-ADD     5             ARR(3)
+     C                   Z-ADD     4             ARR(4)
+     C                   Z-ADD     1             ARR(5)
+     C                   Z-ADD     6             ARR(6)
+     C                   CALLP     STALIN_SORT(ARR : SIZE)
+     C                   EVAl      MSG = MSG + %CHAR(SIZE)
+     C     MSG           DSPLY
+     C                   FOR       I = 1 TO SIZE
+     C     ARR(I)        DSPLY
+     C                   ENDFOR
+     C                   RETURN
+
+     PSTALIN_SORT      B
+     DSTALIN_SORT      PI
+     D ARR                           10I 0 DIM(6)
+     D SIZE                           3U 0
+
+     DI                S                   LIKE(SIZE)
+     DOUT_INDEX        S                   LIKE(SIZE) INZ(1)
+     DNEWSIZE          S                   LIKE(SIZE) INZ(0)
+     DLASTVAL          S             10I 0 INZ(*LOVAL)
+
+     C     SIZE          IFEQ      1
+     C                   RETURN
+     C                   END
+
+     C                   FOR       I = 1 TO SIZE
+     C     ARR(I)        IFGE      LASTVAL
+     C                   Z-ADD     ARR(I)        LASTVAL
+     C     OUT_INDEX     IFNE      I
+     C                   Z-ADD     LASTVAL       ARR(OUT_INDEX)
+     C                   END
+     C     NEWSIZE       ADD       1             NEWSIZE
+     C     OUT_INDEX     ADD       1             OUT_INDEX
+     C                   END
+     C                   ENDFOR
+     C                   Z-ADD     NEWSIZE       SIZE
+     C                   RETURN
+     PSTALIN_SORT      E

--- a/IBM RPG IV/stalin-sort-example-fixed-form.rpgle
+++ b/IBM RPG IV/stalin-sort-example-fixed-form.rpgle
@@ -1,5 +1,7 @@
      H DftActGrp(*No)
 
+     C* Stalin Sort
+
      DARR              S             10I 0 DIM(6)
      DSIZE             S              3U 0 INZ(6)
      DI                S              3U 0

--- a/IBM RPG IV/stalin-sort-example-free-form.rpgle
+++ b/IBM RPG IV/stalin-sort-example-free-form.rpgle
@@ -1,0 +1,43 @@
+**free
+ctl-opt dftactgrp(*no);
+
+dcl-s arr int(10) dim(6);
+dcl-s size uns(3) inz(6);
+dcl-s i uns(3);
+
+arr = %list(1 : 2 : 5 : 4 : 1 : 6);
+stalin_sort(arr : size);
+
+dsply ('New Size : ' + %char(size));
+for i = 1 to size;
+    dsply arr(i);
+endfor;
+return;
+
+dcl-proc stalin_sort;
+    dcl-pi *n;
+        array int(10) dim(6);
+        size uns(3);
+    end-pi;
+
+    dcl-s i like(size);
+    dcl-s write_index like(size) inz(1);
+    dcl-s newsize like(size) inz(0);
+    dcl-s lastval int(10) inz(*loval);
+
+    if size <= 1;
+        return;
+    endif;
+
+    for i = 1 to size;
+        if array(i) >= lastval;
+            lastval = array(i);
+            if write_index <> i;
+                array(write_index) = lastval;
+            endif;
+            newsize += 1;
+            write_index += 1;
+        endif;
+    endfor;
+    size = newsize;
+end-proc;

--- a/IBM RPG IV/stalin-sort-example-free-form.rpgle
+++ b/IBM RPG IV/stalin-sort-example-free-form.rpgle
@@ -1,6 +1,8 @@
 **free
 ctl-opt dftactgrp(*no);
 
+// Stalin Sort
+
 dcl-s arr int(10) dim(6);
 dcl-s size uns(3) inz(6);
 dcl-s i uns(3);


### PR DESCRIPTION
Hi !

Here's an implementation in RPG !
You can learn about this language here :
- https://en.wikipedia.org/wiki/IBM_RPG
- https://www.ibm.com/docs/en/i/7.6.0?topic=languages-rpg

The language is rather tied to IBM environment, here's how to try it :
- https://pub400.com provides free accounts to an IBM machine to try and discover it
- https://www.nicklitten.com/use-a-5250-green-screen-terminal-in-visual-studio/ to get a terminal to access pub400 machine and run code
- https://www.nicklitten.com/connecting-to-pub400-with-vs-code-for-ibm-i/ shows how to code RPG in VSCode and compile it

RPG was designed to code for punched cards, that's why the stalin-sort-fixed-form file looks like weird.
The language has now a new form called free form, which is much more like modern languages (Python for instance), but fixed form is still fully supported.

And take note that if you wish to run it on a IBM machine, filenames have at most 10 characters (the .rpgle extension not being included).