### PR TITLE
Add C++ parallel implementation

### DIFF
--- a/C++/parallel_stalin_sort/common/IJoinable.h
+++ b/C++/parallel_stalin_sort/common/IJoinable.h
@@ -1,0 +1,6 @@
+#pragma once
+
+class IJoinable {
+public:
+    virtual void join() const = 0;
+};

--- a/C++/parallel_stalin_sort/common/ParallelStalinSortArr.h
+++ b/C++/parallel_stalin_sort/common/ParallelStalinSortArr.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <stdexcept>
+
+
+template<typename T>
+class ParallelStalinSortArr{
+public:
+    ParallelStalinSortArr() = delete;
+    ParallelStalinSortArr(T* array, const uint32_t allocatedLength);
+    ParallelStalinSortArr(T* array, const uint32_t allocatedLength, const uint32_t dataLength);
+
+    const T& firstElement() const;
+    const T& lastElement() const;
+
+    std::vector<ParallelStalinSortArr<T>> divide(const uint32_t subArrayCount);
+    void merge(ParallelStalinSortArr<T>& nextSubArray, bool (&comparator)(const T&, const T&));
+
+    uint32_t dataLength;
+    T* array;
+
+private:
+    uint32_t allocatedLength;
+
+    uint32_t findFirstMatchingElementIndex(const T& element, bool (&comparator)(const T&, const T&));
+};
+
+
+
+template<typename T>
+ParallelStalinSortArr<T>::ParallelStalinSortArr(T* array, const uint32_t allocatedLength): 
+    dataLength(allocatedLength), 
+    allocatedLength(allocatedLength), 
+    array(array) {}
+
+template<typename T>
+ParallelStalinSortArr<T>::ParallelStalinSortArr(T* array, const uint32_t allocatedLength, const uint32_t dataLength): 
+    dataLength(dataLength), 
+    allocatedLength(allocatedLength), 
+    array(array) {}
+
+template<typename T>
+const T& ParallelStalinSortArr<T>::firstElement() const {
+    return array[0];
+}
+
+template<typename T>
+const T& ParallelStalinSortArr<T>::lastElement() const {
+    return array[dataLength-1];
+}
+
+template<typename T>
+std::vector<ParallelStalinSortArr<T>> ParallelStalinSortArr<T>::divide(const uint32_t subArrayCount){
+    uint32_t minDataPerSubArr = dataLength / subArrayCount;
+    uint32_t restOfData = dataLength - minDataPerSubArr * subArrayCount;
+    uint32_t tableIterator = 0;
+    std::vector<ParallelStalinSortArr<T>> out;
+    out.reserve(subArrayCount);
+
+    for (uint32_t i = 0; i < subArrayCount; i++){
+        uint32_t applicableRestOfData = restOfData != 0;
+        restOfData -= applicableRestOfData;
+        uint32_t tableSliceLength = minDataPerSubArr + applicableRestOfData;
+        out.push_back(ParallelStalinSortArr(&array[tableIterator], tableSliceLength));
+        tableIterator += tableSliceLength;
+    }
+
+    return out;
+}
+
+template<typename T>
+void ParallelStalinSortArr<T>::merge(ParallelStalinSortArr<T>& nextSubArray, bool (&comparator)(const T&, const T&)){
+    this->allocatedLength += nextSubArray.allocatedLength;
+
+    uint32_t firstMatchingElementIndex = 0;
+    if (comparator(this->lastElement(), nextSubArray.lastElement()) == false){
+        return;
+    } else if (comparator(this->lastElement(), nextSubArray.firstElement()) == false){
+        firstMatchingElementIndex = nextSubArray.findFirstMatchingElementIndex(this->lastElement(), comparator);
+    }
+
+    for (uint32_t i = firstMatchingElementIndex; i < nextSubArray.dataLength; i++){
+        this->array[this->dataLength] = nextSubArray.array[i];
+        this->dataLength++;
+    }
+}
+
+template<typename T>
+uint32_t ParallelStalinSortArr<T>::findFirstMatchingElementIndex(const T& element, bool (&comparator)(const T&, const T&)){
+    uint32_t searchIndex = dataLength / 2;
+    uint32_t searchInterval = dataLength / 4;
+    while (searchInterval > 1){
+        if (comparator(element, array[searchIndex]) == true) {
+            searchIndex += searchInterval;
+        } else {
+            searchIndex -= searchInterval;
+        }
+        searchInterval /= 2;
+    }
+    
+    if (comparator(element, array[searchIndex]) == true) {
+        do {
+            searchIndex--;
+        } while (searchIndex != uint32_t(-1) && comparator(element, array[searchIndex]) == true);
+        searchIndex++;
+    } else {
+        do {
+            searchIndex++;
+        } while (searchIndex < dataLength && comparator(element, array[searchIndex]) == false);
+    }
+    return searchIndex;
+}

--- a/C++/parallel_stalin_sort/common/SyncableThread.h
+++ b/C++/parallel_stalin_sort/common/SyncableThread.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <thread>
+#include <shared_mutex>
+#include <mutex>
+#include <stdexcept>
+#include "IJoinable.h"
+
+
+template<typename... _Args>
+class SyncableThread : public IJoinable {
+public:
+    SyncableThread(void(&function)(_Args...), std::shared_mutex& syncMutex);
+    ~SyncableThread();
+
+    void start(const _Args&... args);
+    void join() const override;
+
+    bool isRunning() const;
+
+private:
+    bool running;
+    std::thread* thread;
+    std::shared_mutex& syncMutex;
+    void(&function)(_Args...);
+    
+    void threadFunction(const _Args&... args);
+};
+
+template<typename... _Args>
+SyncableThread<_Args...>::SyncableThread(void(&function)(_Args...), std::shared_mutex& syncMutex): 
+    function(function), 
+    running(false), 
+    thread(nullptr), 
+    syncMutex(syncMutex) {}
+
+template<typename... _Args>
+SyncableThread<_Args...>::~SyncableThread(){
+    if (thread != nullptr){
+        delete thread;
+    }
+}
+
+template<typename... _Args>
+void SyncableThread<_Args...>::start(const _Args&... args){
+    if (running) {
+        throw std::runtime_error("Cannot start thread while thread is running");
+    }
+    if (thread != nullptr){
+        thread->join();
+        delete thread;
+    }
+    thread = new std::thread(&SyncableThread<_Args...>::threadFunction, this, args...);
+}
+
+template<typename... _Args>
+void SyncableThread<_Args...>::join() const {
+    if (thread != nullptr && thread->joinable()) {
+        thread->join();
+    }
+}
+
+template<typename... _Args>
+bool SyncableThread<_Args...>::isRunning() const {
+    return running;
+}
+
+template<typename... _Args>
+void SyncableThread<_Args...>::threadFunction(const _Args&... args){
+    std::shared_lock<std::shared_mutex> lock(syncMutex);
+    running = true;
+    function(args...);
+    running = false;
+    lock.unlock();
+}

--- a/C++/parallel_stalin_sort/common/ThreadGroup.h
+++ b/C++/parallel_stalin_sort/common/ThreadGroup.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "SyncableThread.h"
+
+
+template<typename... _Args>
+class ThreadGroup {
+public:
+    ThreadGroup(uint32_t threads, void(&function)(_Args...));
+
+    void setArgs(uint32_t threadIndex, const _Args&... args);
+
+    void start();
+    void synchronousStart();
+    void join() const;
+    std::vector<const IJoinable*> getJoinHandles() const;
+
+    uint32_t size() const;
+
+private:
+    std::shared_mutex syncMutex;
+    std::vector<SyncableThread<_Args...>> threads;
+    std::vector<std::tuple<_Args...>> args;
+};
+
+
+template<typename... _Args>
+ThreadGroup<_Args...>::ThreadGroup(uint32_t threads, void(&function)(_Args...)) : 
+    syncMutex(),
+    threads(threads, SyncableThread<_Args...>(function, syncMutex)),
+    args(threads) {}
+
+template<typename... _Args>
+void ThreadGroup<_Args...>::setArgs(uint32_t threadIndex, const _Args&... args){
+    if (threadIndex >= this->args.size()) {
+        throw std::out_of_range("Invalid thread index");
+    }
+    this->args[threadIndex] = std::make_tuple(args...);
+}
+
+template<typename... _Args>
+void ThreadGroup<_Args...>::start(){
+    for (uint32_t i = 0; i < threads.size(); i++){
+        threads[i].start(std::get<_Args>(args[i])...);
+    }
+}
+
+template<typename... _Args>
+void ThreadGroup<_Args...>::synchronousStart(){
+    std::unique_lock<std::shared_mutex> lock(syncMutex);
+    start();
+    lock.unlock();
+}
+
+template<typename... _Args>
+void ThreadGroup<_Args...>::join() const {
+    for (uint32_t i = 0; i < threads.size(); i++){
+        threads[i].join();
+    }
+}
+
+template<typename... _Args>
+std::vector<const IJoinable*> ThreadGroup<_Args...>::getJoinHandles() const {
+    std::vector<const IJoinable*> handles;
+    handles.reserve(threads.size());
+    for (uint32_t i = 0; i < threads.size(); i++){
+        handles.push_back(&threads[i]);
+    }
+    return handles;
+}
+
+template<typename... _Args>
+uint32_t ThreadGroup<_Args...>::size() const {
+    return threads.size();
+}

--- a/C++/parallel_stalin_sort/common/stalinSortMerge.h
+++ b/C++/parallel_stalin_sort/common/stalinSortMerge.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "ThreadGroup.h"
+#include "ParallelStalinSortArr.h"
+#include "standardStalinSort.h"
+
+
+template<typename T>
+void stalinSortMerge(uint32_t threadIndex, std::vector<ParallelStalinSortArr<T>>* arrays, const std::vector<const IJoinable*>* threads, comparatorSignature<T>* comparator) {
+    std::vector<ParallelStalinSortArr<T>>& arraysRef = *arrays;
+    const std::vector<const IJoinable*>& threadsRef = *threads;
+
+    uint32_t mergeIncrementor = 1;
+    ParallelStalinSortArr<T>& workArray = arraysRef[threadIndex * 2];
+    uint32_t mergeArrIndex = threadIndex * 2 + 1;
+
+    while (true){
+        workArray.merge(arraysRef[mergeArrIndex], *comparator);
+        
+        uint32_t mergeThreadIndex = threadIndex | mergeIncrementor;
+        mergeArrIndex = mergeThreadIndex * 2;
+        if (mergeThreadIndex == threadIndex || mergeArrIndex >= arraysRef.size() || mergeThreadIndex >= threadsRef.size()){
+            break;
+        }
+        threadsRef[mergeThreadIndex]->join();
+        mergeIncrementor <<= 1;
+    }
+
+    if (threadIndex == threadsRef.size() - 1 && (arraysRef.size() & 0x1) == 0x1) {
+        mergeArrIndex = arraysRef.size() - 1;
+        workArray.merge(arraysRef[mergeArrIndex], *comparator);
+    }
+}

--- a/C++/parallel_stalin_sort/common/standardStalinSort.h
+++ b/C++/parallel_stalin_sort/common/standardStalinSort.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include "ParallelStalinSortArr.h"
+
+
+template<typename T>
+using comparatorSignature = bool (const T&, const T&);
+
+template<typename T>
+bool decreasingComparator(const T& a, const T& b){
+    return a >= b;
+}
+
+template<typename T>
+uint32_t standardStalinSort(T* array, uint32_t tableSize, comparatorSignature<T>& comparator = &decreasingComparator<T>){
+    uint32_t endOfData = 0;
+    uint32_t i = 1;
+    for (; i < tableSize; i++){
+        if (comparator(array[endOfData], array[i]) == false){
+            break;
+        }
+        endOfData++;
+    }
+    for (; i < tableSize; i++){
+        if (comparator(array[endOfData], array[i]) == true){
+            endOfData++;
+            array[endOfData] = array[i];
+        }
+    }
+    return endOfData + 1;
+}
+
+template<typename T>
+void standardStalinSort(ParallelStalinSortArr<T>* array, comparatorSignature<T>* comparator = &decreasingComparator<T>){
+    array->dataLength = standardStalinSort<T>(array->array, array->dataLength, *comparator);
+}

--- a/C++/parallel_stalin_sort/parallel_stalin_sort.h
+++ b/C++/parallel_stalin_sort/parallel_stalin_sort.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "common/ThreadGroup.h"
+#include "common/ParallelStalinSortArr.h"
+#include "common/standardStalinSort.h"
+#include "common/stalinSortMerge.h"
+
+
+/// @brief Performs a parallel Stalin sort on the given array. Gives performance improvements only on large arrays (more than a few million elements).
+/// @tparam T - Type of the elements in the array.
+/// @param array - Pointer to the array to be sorted.
+/// @param tableSize - Size of the array.
+/// @param threadCount - Number of threads to use for sorting.
+/// @param comparator - Comparator function to use for sorting.
+/// @return - The new size of the array after sorting.
+template<typename T>
+uint32_t stalinSort(T* array, uint32_t tableSize, uint32_t threadCount, comparatorSignature<T>& comparator = &decreasingComparator<T>);
+
+
+template<typename T>
+class ParallelStalinSort {
+public:
+    ParallelStalinSort(uint32_t threadCount, comparatorSignature<T>& comparator);
+
+    uint32_t sort(T* array, uint32_t tableSize); 
+
+private:
+    ThreadGroup<ParallelStalinSortArr<T>*, comparatorSignature<T>*> sortThreads;
+    ThreadGroup<uint32_t, std::vector<ParallelStalinSortArr<T>>*, const std::vector<const IJoinable*>*, comparatorSignature<T>*> mergeThreads;
+    const std::vector<const IJoinable*> mergeThreadsHandles;
+    comparatorSignature<T>& comparator;
+
+    void setupThreads(std::vector<ParallelStalinSortArr<T>>& dividedData);
+};
+
+
+
+template<typename T>
+ParallelStalinSort<T>::ParallelStalinSort(uint32_t threadCount, comparatorSignature<T>& comparator) :
+    sortThreads(threadCount, standardStalinSort<T>),
+    mergeThreads(threadCount / 2, stalinSortMerge<T>),
+    mergeThreadsHandles(mergeThreads.getJoinHandles()),
+    comparator(comparator) {}
+
+template<typename T>
+uint32_t ParallelStalinSort<T>::sort(T* array, uint32_t tableSize){
+    if (tableSize <= this->sortThreads.size()) {
+        return standardStalinSort(array, tableSize, comparator);
+    }
+
+    std::vector<ParallelStalinSortArr<T>> dividedData = ParallelStalinSortArr<T>(array, tableSize).divide(sortThreads.size());
+    setupThreads(dividedData);
+
+    sortThreads.start();
+    sortThreads.join();
+    mergeThreads.synchronousStart();
+    mergeThreads.join();
+
+    return dividedData[0].dataLength;
+}
+
+template<typename T>
+void ParallelStalinSort<T>::setupThreads(std::vector<ParallelStalinSortArr<T>>& dividedData){
+    for (uint32_t i = 0; i < sortThreads.size(); i++){
+        sortThreads.setArgs(i, &dividedData[i], comparator);
+    }
+    for (uint32_t i = 0; i < mergeThreads.size(); i++){
+        mergeThreads.setArgs(i, i, &dividedData, &mergeThreadsHandles, &comparator);
+    }
+}
+
+
+template<typename T>
+uint32_t stalinSort(T* array, uint32_t tableSize, uint32_t threadCount, comparatorSignature<T>& comparator) {
+    return ParallelStalinSort<T>(threadCount, comparator).sort(array, tableSize);
+};


### PR DESCRIPTION
This introduces a new paradigm to stalin sort algorithm.  This may not be the most optimal implementation but it illustrates that there are still undiscovered possibilities. 
While comparing `standardStalinSort()` and `ParallelStalinSort::sort()`  I get around 1.5x performance improvement using 4 threads and sorting array containing a few milion elements. At most I was able to get 2x performance improvement using 12 threads and 300M element array.
It is clearly possible to add CUDA, OpenCL ect. implementations that will use GPU capabilities (and not just one GPU thread). I can see at least two distinct solutions, but not sure if I will have much time to experiment on that.