### PR TITLE
feat: Added Verilog implementation of Stalin Sort

### DIFF
--- a/verilog/stalin_sort.v
+++ b/verilog/stalin_sort.v
@@ -1,0 +1,111 @@
+// Stalin Sort
+// Verilog-2001, synthesizable
+module stalin_sort #(
+    // number of input elements
+    parameter integer N = 16,
+    // bit width per element
+    parameter integer WIDTH = 8,
+    // initial value of 'bigger' (assumes unsigned)
+    parameter integer INIT_BIGGER = 0
+)(
+    input  wire                   clk,
+    input  wire                   rst_n,
+    // 1-cycle pulse to start
+    input  wire                   start,
+    // concatenated input: element 0 at LSB side
+    input  wire [N*WIDTH-1:0]     data_in,
+    // concatenated output: densely packed at 0..out_len-1
+    output reg  [N*WIDTH-1:0]     data_out,
+    // number of kept elements
+    output reg  [CLOG2(N+1)-1:0]  out_len,
+    // result valid when 1
+    output reg                    done
+);
+
+    // clog2 implementation
+    function integer CLOG2;
+        input integer value;
+        integer v, i;
+        begin
+            v = value - 1;
+            for (i = 0; v > 0; i = i + 1) v = v >> 1;
+            CLOG2 = i;
+        end
+    endfunction
+
+    // internal registers
+    reg [WIDTH-1:0] bigger;
+    // input scan index
+    reg [CLOG2(N+1)-1:0] i_idx;
+    // output write index
+    reg [CLOG2(N+1)-1:0] o_idx;
+
+    // FSM states
+    localparam S_IDLE = 2'd0,
+               S_RUN  = 2'd1,
+               S_DONE = 2'd2;
+    reg [1:0] state;
+
+    // helper: read i-th element from data_in
+    wire [WIDTH-1:0] cur = data_in[i_idx*WIDTH +: WIDTH];
+
+    // keep data_out in a register and overwrite only the kept elements
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state   <= S_IDLE;
+            i_idx   <= {CLOG2(N+1){1'b0}};
+            o_idx   <= {CLOG2(N+1){1'b0}};
+            bigger  <= {WIDTH{1'b0}};
+            out_len <= {CLOG2(N+1){1'b0}};
+            data_out<= {N*WIDTH{1'b0}};
+            done    <= 1'b0;
+        end else begin
+            case (state)
+                S_IDLE: begin
+                    done    <= 1'b0;
+                    if (start) begin
+                        // initialize
+                        i_idx   <= 0;
+                        o_idx   <= 0;
+                        bigger  <= INIT_BIGGER[WIDTH-1:0];
+                        out_len <= 0;
+                        data_out<= {N*WIDTH{1'b0}};
+                        state   <= S_RUN;
+                    end
+                end
+
+                S_RUN: begin
+                    // process one element per cycle while i_idx < N
+                    if (i_idx < N) begin
+                        if (cur >= bigger) begin
+                            // keep -> write to output (packed)
+                            data_out[o_idx*WIDTH +: WIDTH] <= cur;
+                            o_idx   <= o_idx + 1'b1;
+                            out_len <= o_idx + 1'b1;
+                            bigger  <= cur;
+                        end
+                        i_idx <= i_idx + 1'b1;
+                    end else begin
+                        state <= S_DONE;
+                    end
+                end
+
+                S_DONE: begin
+                    done <= 1'b1;
+                    // restart on start
+                    if (start) begin
+                        i_idx    <= 0;
+                        o_idx    <= 0;
+                        bigger   <= INIT_BIGGER[WIDTH-1:0];
+                        out_len  <= 0;
+                        data_out <= {N*WIDTH{1'b0}};
+                        done     <= 1'b0;
+                        state    <= S_RUN;
+                    end
+                end
+
+                default: state <= S_IDLE;
+            endcase
+        end
+    end
+endmodule

--- a/verilog/tb_stalin_sort.v
+++ b/verilog/tb_stalin_sort.v
@@ -1,0 +1,111 @@
+`timescale 1ns/1ps
+
+module tb_stalin_sort;
+    localparam integer N     = 6;
+    localparam integer WIDTH = 8;
+
+    reg                      clk;
+    reg                      rst_n;
+    reg                      start;
+    reg  [N*WIDTH-1:0]       data_in;
+    wire [N*WIDTH-1:0]       data_out;
+    wire [$clog2(N+1)-1:0]   out_len;
+    wire                     done;
+
+    stalin_sort #(
+        .N(N),
+        .WIDTH(WIDTH),
+        .INIT_BIGGER(0)
+    ) dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .start(start),
+        .data_in(data_in),
+        .data_out(data_out),
+        .out_len(out_len),
+        .done(done)
+    );
+
+    initial clk = 0;
+    always #5 clk = ~clk;
+
+    function [WIDTH-1:0] get_elem;
+        input [N*WIDTH-1:0] vec;
+        input integer idx;
+        begin
+            get_elem = vec[idx*WIDTH +: WIDTH];
+        end
+    endfunction
+
+    function [N*WIDTH-1:0] pack6;
+        input [WIDTH-1:0] a0,a1,a2,a3,a4,a5;
+        begin
+            pack6 = {a5,a4,a3,a2,a1,a0};
+        end
+    endfunction
+
+    task check_result;
+        input integer exp_len;
+        input [N*WIDTH-1:0] exp_vec;
+        integer k;
+        reg [WIDTH-1:0] got, exp;
+        begin
+            if (out_len !== exp_len) begin
+                $display("[ERROR] out_len mismatch: got=%0d exp=%0d", out_len, exp_len);
+                $fatal;
+            end
+            for (k = 0; k < exp_len; k = k + 1) begin
+                got = get_elem(data_out, k);
+                exp = get_elem(exp_vec, k);
+                if (got !== exp) begin
+                    $display("[ERROR] data_out[%0d] mismatch: got=%0d exp=%0d", k, got, exp);
+                    $fatal;
+                end
+            end
+            $display("[OK] result matched. len=%0d", exp_len);
+        end
+    endtask
+
+    initial begin
+        $dumpfile("dump.vcd");
+        $dumpvars(0, tb_stalin_sort);
+
+        rst_n   = 0;
+        start   = 0;
+        data_in = 0;
+
+        repeat (3) @(posedge clk);
+        rst_n = 1;
+        @(posedge clk);
+
+        // ---- Test 1 ----
+        // Input: [3,1,2,2,5,4]
+        data_in = pack6(8'd3, 8'd1, 8'd2, 8'd2, 8'd5, 8'd4);
+        start = 1; @(posedge clk); start = 0;
+        wait (done == 1);
+        // Expect: [3,5,*,*,*,*]
+        check_result(2, pack6(8'd3, 8'd5, 8'd0, 8'd0, 8'd0, 8'd0));
+
+        // ---- Test 2 ----
+        // Input: [1,2,3,4,5,6]
+        @(posedge clk);
+        data_in = pack6(8'd1,8'd2,8'd3,8'd4,8'd5,8'd6);
+        start = 1; @(posedge clk); start = 0;
+        wait (done == 1);
+        // Expect: [1,2,3,4,5,6]
+        check_result(6, pack6(8'd1,8'd2,8'd3,8'd4,8'd5,8'd6));
+
+        // ---- Test 3 ----
+        // Input: [9,8,7,6,5,4]
+        @(posedge clk);
+        data_in = pack6(8'd9,8'd8,8'd7,8'd6,8'd5,8'd4);
+        start = 1; @(posedge clk); start = 0;
+        wait (done == 1);
+        // Expect: [9,*,*,*,*,*]
+        check_result(1, pack6(8'd9,8'd0,8'd0,8'd0,8'd0,8'd0));
+
+        $display("All tests passed.");
+        $finish;
+    end
+
+endmodule


### PR DESCRIPTION
Hi, I added Verilog implementation.

Verilog is a hardware description language for FPGA, so simulation is required to run it on a general-purpose PC.

The results of the tests conducted through simulation are as follows.

```shell
$ iverilog -g2005-sv -o simv stalin_sort.v tb_stalin_sort.v
$ vvp simv
VCD info: dumpfile dump.vcd opened for output.
[OK] result matched. len=2
[OK] result matched. len=6
[OK] result matched. len=1
All tests passed.
tb_stalin_sort.v:110: $finish called at 295000 (1ps)
```