### PR TITLE
feat: Add LaTeX implementation of Stalin sort

### DIFF
--- a/latex/stalinsort.tex
+++ b/latex/stalinsort.tex
@@ -1,0 +1,37 @@
+\documentclass{article}
+\usepackage{expl3,xparse}
+\ExplSyntaxOn
+
+\int_new:N \l__ss_max_int
+\int_new:N \l__ss_tmp_int
+\clist_new:N \l__ss_out_clist
+
+\cs_new_protected:Npn \stalin_sort:n #1
+  {
+    \int_set:Nn \l__ss_max_int { -2147483647 }
+    \clist_clear:N \l__ss_out_clist
+
+    \clist_map_inline:nn {#1}
+      {
+        \int_set:Nn \l__ss_tmp_int { ##1 }
+        \int_compare:nTF { \l__ss_tmp_int >= \l__ss_max_int }
+          {
+            \int_set_eq:NN \l__ss_max_int \l__ss_tmp_int
+            \clist_put_right:Nx \l__ss_out_clist { \int_use:N \l__ss_tmp_int }
+          }
+          { }
+      }
+
+    \clist_use:Nn \l__ss_out_clist {,~}
+  }
+
+\NewDocumentCommand{\StalinSort}{m}
+  { \stalin_sort:n {#1} }
+
+\ExplSyntaxOff
+
+\begin{document}
+Input: 1, 2, 5, 3, 5, 7
+
+Output: \StalinSort{1, 2, 5, 3, 5, 7}
+\end{document}


### PR DESCRIPTION
I added a new file stalinsort.tex implementing a LaTeX command to perform Stalin sort on a list of integers.

I tested this implementation on overleaf, an online latex editor.

<img width="1412" height="834" alt="Screenshot 2025-08-26 at 11 19 37 PM" src="https://github.com/user-attachments/assets/119e11c2-97e0-42c4-9d8c-270213dde82a" />
