### PR TITLE
feat(js): add O(n) implementation

### DIFF
--- a/javascript/stalin-sort-for.js
+++ b/javascript/stalin-sort-for.js
@@ -1,0 +1,25 @@
+function stalinSort(array) {
+  if (!Array.isArray(array)) {
+    throw new TypeError('Argument must be an Array!');
+  }
+  
+  if (array.length <= 1) {
+    return array;
+  }
+  
+  let writeIndex = 1;
+  let lastValid = array[0];
+  
+  for (let readIndex = 1; readIndex < array.length; readIndex++) {
+    if (array[readIndex] >= lastValid) {
+      array[writeIndex] = array[readIndex];
+      lastValid = array[readIndex];
+      writeIndex++;
+    }
+  }
+  
+  array.length = writeIndex;
+  return array;
+}
+
+module.exports = stalinSort


### PR DESCRIPTION
This implementation:
- is O(n)
- does not create an extra array, only two number variables (assuming it is an arrary of numbers)